### PR TITLE
Fix: Support table creation for Laravel migrations on Firebird 2.5

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -4,9 +4,31 @@ declare(strict_types=1);
 
 namespace Danidoble\Firebird\Schema;
 
+use Closure;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
 
 class Builder extends SchemaBuilder
 {
-    //
+    public function create($table, Closure $callback): void
+    {
+        parent::create($table, $callback);
+
+        if ($table === 'migrations') {
+            $serverVersion = $this->connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+            if (version_compare($serverVersion, '3.0', '<')) {
+                $this->connection->statement('CREATE GENERATOR "GEN_MIGRATIONS_ID"');
+                $this->connection->statement('SET GENERATOR "GEN_MIGRATIONS_ID" TO 0');
+                $this->connection->statement('
+                    CREATE TRIGGER "TRG_MIGRATIONS_ID" FOR "migrations"
+                    ACTIVE BEFORE INSERT POSITION 0
+                    AS
+                    BEGIN
+                        IF (NEW."id" IS NULL OR NEW."id" = 0) THEN
+                            NEW."id" = NEXT VALUE FOR "GEN_MIGRATIONS_ID";
+                    END
+                ');
+            }
+        }
+    }
 }


### PR DESCRIPTION
Description
This PR fixes a validation error (-625 validation error for column "migrations"."id") that occurs on Firebird 2.5 when running php artisan migrate for the first time.

Cause of the Bug
The core Laravel framework creates the migrations repository table in an isolated way (DatabaseMigrationRepository), bypassing the standard Blueprint event listeners that this package uses to generate SEQUENCE (Generator) and TRIGGER for user-defined tables.

On Firebird 3.0+, this is not an issue if the driver generates column definition natively or handles it through newer features. However, on Firebird 2.5, the table is created as a plain INTEGER NOT NULL without any auto-increment mechanism. When Laravel immediately attempts to insert the first batch record, the database rejects the command due to the missing ID.

Solution
We extended the Schema\Builder::create method to intercept when the migrations table is being created.

To prevent breaking compatibility with Firebird 3.0+ (where manual generators/triggers for standard IDs are often omitted or handle differently), the code inspects the server version using \PDO::ATTR_SERVER_VERSION.

If the server version is lower than 3.0 (i.e., Firebird 2.5), it manually injects the required GENERATOR and BEFORE INSERT TRIGGER right after the table structure is built, but before Laravel executes any inserts.

For Firebird 3.0+, the behavior remains completely untouched.

How to test
Use a Firebird 2.5 database instance.

Run php artisan migrate on a fresh database.

The migrations table should be created successfully and the initial batch recorded without validation failures.